### PR TITLE
fix bug in order of setting file paths and printing them to user

### DIFF
--- a/workflow/scripts/compute_ins_chip.py
+++ b/workflow/scripts/compute_ins_chip.py
@@ -185,13 +185,13 @@ def main(args):
         os.mkdir(args.outdir)
     
     # correlation matrix
-    print(f'writing tf-peak correlations to {corr_outfile}...')
     corr_outfile = args.outdir +'/tf_peak_corrs.mtx'
+    print(f'writing tf-peak correlations to {corr_outfile}...')
     scipy.io.mmwrite(corr_outfile, csr_matrix(corr_mat.values), )    
     
     # in silico ChIP matrices
-    print(f'writing in silico ChIP matrix to {ins_outfile}...')
     ins_outfile = args.outdir +'/ins_chip.mtx'
+    print(f'writing in silico ChIP matrix to {ins_outfile}...')
     scipy.io.mmwrite(ins_outfile, csr_matrix(insc_mat.values), )
     
     # TF and peak list


### PR DESCRIPTION
Implemented a fix for this bug in the script for the `compute_ins_chip` rule by assigning the variable to the desired file path before printing. 
```
Traceback (most recent call last):
  File "workflow/scripts/compute_ins_chip.py", line 206, in <module>
    main(args)
  File "workflow/scripts/compute_ins_chip.py", line 188, in main
    print(f'writing tf-peak correlations to {corr_outfile}...')
UnboundLocalError: local variable 'corr_outfile' referenced before assignment
```