### PR TITLE
link `compute_ins_chip` to `peak_tf`

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -200,6 +200,7 @@ rule peak_scores:
 # ---- In Silico ChIP Rules ---- #
 rule compute_ins_chip:
     input:
+        peak_tf = output_dir + "peak_tf/",
         atac = config["anndata"]["atac"],
         rna = config["anndata"]["rna"],
         sc_atac = config["anndata"]["sc_atac"],


### PR DESCRIPTION
Add input to `compute_ins_chip` rule to properly link it to the `peak_tf` rule without changing other behavior.

Closes #18.