### PR TITLE
Replace NA values with 0 in row data of fragment_counts

### DIFF
--- a/workflow/scripts/run_chromvar.R
+++ b/workflow/scripts/run_chromvar.R
@@ -22,6 +22,10 @@ names(col_data) <- 'depth'
 
 fragment_counts <- SummarizedExperiment(assays=list(counts=count_matrix), rowRanges=peaks, colData=col_data)
 fragment_counts <- addGCBias(fragment_counts, genome=genome)
+row.data <- data.frame(rowData(fragment_counts))
+row.data[is.na(fragment_counts)] <- 0
+rowData(fragment_counts) <- row.data
+
 counts_filtered <- filterPeaks(fragment_counts, non_overlapping=TRUE)
 
 tf_names <- readr::read_csv(sprintf("%s/chromvar_tf_names.csv", chromvar_indir))


### PR DESCRIPTION
Handle NA values in fragment counts for chromVAR by replacing them with 0.

Closes #20.